### PR TITLE
BUG: Use correct return deviceclass and stateclass for sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# No Longer Maintained
+@865charlesw had some major life changes and took a break from this project, you may have better luck with @tache's [fork][fork]
 # Kidde HomeSafe Integration
 
 _Integration to integrate with [Kidde HomeSafe][kidde_homesafe]._
@@ -21,3 +23,4 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 
 [hacs_custom_repo]: https://hacs.xyz/docs/faq/custom_repositories/
 [kidde_homesafe]: https://github.com/865charlesw/kidde-homesafe
+[fork]: https://github.com/tache/homeassistant-kidde

--- a/custom_components/kidde/binary_sensor.py
+++ b/custom_components/kidde/binary_sensor.py
@@ -1,8 +1,12 @@
 """Binary sensor platform for Kidde Homesafe integration."""
+
 from __future__ import annotations
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -14,12 +18,22 @@ from .entity import KiddeEntity
 
 _BINARY_SENSOR_DESCRIPTIONS = (
     BinarySensorEntityDescription(
-        "smoke_alarm", icon="mdi:smoke-detector-variant-alert", name="Smoke Alarm"
+        "smoke_alarm",
+        icon="mdi:smoke-detector-variant-alert",
+        name="Smoke Alarm",
+        device_class=BinarySensorDeviceClass.SMOKE,
     ),
     BinarySensorEntityDescription(
-        "smoke_hushed", icon="mdi:smoke-detector-variant-off", name="Smoke Hushed"
+        "smoke_hushed",
+        icon="mdi:smoke-detector-variant-off",
+        name="Smoke Hushed",
     ),
-    BinarySensorEntityDescription("co_alarm", icon="mdi:molecule-co", name="CO Alarm"),
+    BinarySensorEntityDescription(
+        "co_alarm",
+        icon="mdi:molecule-co",
+        name="CO Alarm",
+        device_class=BinarySensorDeviceClass.CO,
+    ),
 )
 
 

--- a/custom_components/kidde/manifest.json
+++ b/custom_components/kidde/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/865charlesw/homeassistant-kidde-homesafe/issues",
   "requirements": ["kidde-homesafe"],
-  "version": "main"
+  "version": "0.0.0.dev"
 }

--- a/custom_components/kidde/manifest.json
+++ b/custom_components/kidde/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/865charlesw/homeassistant-kidde-homesafe/issues",
   "requirements": ["kidde-homesafe"],
-  "version": "0.0.0"
+  "version": "0.0.4"
 }

--- a/custom_components/kidde/manifest.json
+++ b/custom_components/kidde/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/865charlesw/homeassistant-kidde-homesafe/issues",
   "requirements": ["kidde-homesafe"],
-  "version": "0.0.3"
+  "version": "main"
 }

--- a/custom_components/kidde/manifest.json
+++ b/custom_components/kidde/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/865charlesw/homeassistant-kidde-homesafe/issues",
   "requirements": ["kidde-homesafe"],
-  "version": "0.0.0.dev"
+  "version": "0.0.0"
 }

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -1,5 +1,6 @@
 """Sensor platform for Kidde Homesafe integration."""
 from __future__ import annotations
+import logging
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -24,6 +25,8 @@ from .const import DOMAIN
 from .coordinator import KiddeCoordinator
 from .entity import KiddeEntity
 
+
+logger = logging.getLogger(__name__)
 
 _SENSOR_DESCRIPTIONS = (
     SensorEntityDescription("smoke_level", icon="mdi:smoke", name="Smoke Level"),
@@ -98,7 +101,10 @@ class KiddeSensorEntity(KiddeEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        return self.kidde_device.get(self.entity_description.key)
+        value = self.kidde_device.get(self.entity_description.key)
+        dtype = type(value)
+        logger.debug(f"{self.entity_description.key} of type {dtype} is {value}")
+        return value
 
 class KiddeSensorMeasurementEntity(KiddeEntity, SensorEntity):
     """Measurement Sensor for Kidde HomeSafe."""

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -29,21 +29,28 @@ from .entity import KiddeEntity
 logger = logging.getLogger(__name__)
 
 _SENSOR_DESCRIPTIONS = (
-    SensorEntityDescription("smoke_level", icon="mdi:smoke", name="Smoke Level"),
-    SensorEntityDescription("co_level", icon="mdi:molecule-co", name="CO Level"),
+    SensorEntityDescription("smoke_level", icon="mdi:smoke", name="Smoke Level",
+                            device_class=SensorDeviceClass.AQI,),
+    SensorEntityDescription("co_level", icon="mdi:molecule-co", name="CO Level",
+                            device_class=SensorDeviceClass.CO,),
     SensorEntityDescription(
-        "battery_state", icon="mdi:battery-alert", name="Battery State"
+        "battery_state", icon="mdi:battery-alert", name="Battery State",
+        device_class=SensorDeviceClass.ENUM,
+        options=['ok', 'failed'],
     ),
-    SensorEntityDescription("last_seen", icon="mdi:home-clock", name="Last Seen"),
+    SensorEntityDescription("last_seen", icon="mdi:home-clock", name="Last Seen",
+                            device_class=SensorDeviceClass.TIMESTAMP,),
     SensorEntityDescription(
-        "last_test_time", icon="mdi:home-clock", name="Last Test Time"
+        "last_test_time", icon="mdi:home-clock", name="Last Test Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
     ),
     SensorEntityDescription(
-        "overall_iaq_status", icon="mdi:air-filter", name="Overall Air Quality"
+        "overall_iaq_status", icon="mdi:air-filter", name="Overall Air Quality",
+        device_class=SensorDeviceClass.AQI,
     ),
     SensorEntityDescription(
         "life", icon="mdi:calendar-clock", name="Weeks to replace",
-        state_class=SensorStateClass.MEASUREMENT, native_unit_of_measurement=UnitOfTime.WEEKS
+        state_class=SensorStateClass.MEASUREMENT, native_unit_of_measurement=UnitOfTime.WEEKS,
     ),
 )
 

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.components.number import NumberDeviceClass
 from homeassistant.const import (
     UnitOfTemperature,
     PERCENTAGE,
@@ -34,12 +33,14 @@ _SENSOR_DESCRIPTIONS = (
         "smoke_level",
         icon="mdi:smoke",
         name="Smoke Level",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.AQI,
     ),
     SensorEntityDescription(
         "co_level",
         icon="mdi:molecule-co",
         name="CO Level",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CO,
     ),
     SensorEntityDescription(
@@ -47,25 +48,22 @@ _SENSOR_DESCRIPTIONS = (
         icon="mdi:battery-alert",
         name="Battery State",
         device_class=SensorDeviceClass.ENUM,
+        state_class=SensorStateClass.MEASUREMENT,
         options=["ok", "failed"],
     ),
     SensorEntityDescription(
         "last_seen",
         icon="mdi:home-clock",
         name="Last Seen",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     SensorEntityDescription(
         "last_test_time",
         icon="mdi:home-clock",
         name="Last Test Time",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
-    ),
-    SensorEntityDescription(
-        "overall_iaq_status",
-        icon="mdi:air-filter",
-        name="Overall Air Quality",
-        device_class=SensorDeviceClass.AQI,
     ),
     SensorEntityDescription(
         "life",
@@ -77,6 +75,12 @@ _SENSOR_DESCRIPTIONS = (
 )
 
 _MEASUREMENTSENSOR_DESCRIPTIONS = (
+    SensorEntityDescription(
+        "overall_iaq_status",
+        icon="mdi:air-filter",
+        name="Overall Air Quality",
+        device_class=SensorDeviceClass.AQI,
+    ),
     SensorEntityDescription(
         "iaq_temperature",
         name="Indoor Temperature",

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for Kidde Homesafe integration."""
+
 from __future__ import annotations
 import logging
 
@@ -6,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
-    SensorDeviceClass
+    SensorDeviceClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -18,7 +19,7 @@ from homeassistant.const import (
     UnitOfPressure,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
-    UnitOfTime
+    UnitOfTime,
 )
 
 from .const import DOMAIN
@@ -29,55 +30,82 @@ from .entity import KiddeEntity
 logger = logging.getLogger(__name__)
 
 _SENSOR_DESCRIPTIONS = (
-    SensorEntityDescription("smoke_level", icon="mdi:smoke", name="Smoke Level",
-                            device_class=SensorDeviceClass.AQI,),
-    SensorEntityDescription("co_level", icon="mdi:molecule-co", name="CO Level",
-                            device_class=SensorDeviceClass.CO,),
     SensorEntityDescription(
-        "battery_state", icon="mdi:battery-alert", name="Battery State",
-        device_class=SensorDeviceClass.ENUM,
-        options=['ok', 'failed'],
-    ),
-    SensorEntityDescription("last_seen", icon="mdi:home-clock", name="Last Seen",
-                            device_class=SensorDeviceClass.TIMESTAMP,),
-    SensorEntityDescription(
-        "last_test_time", icon="mdi:home-clock", name="Last Test Time",
-        device_class=SensorDeviceClass.TIMESTAMP,
-    ),
-    SensorEntityDescription(
-        "overall_iaq_status", icon="mdi:air-filter", name="Overall Air Quality",
+        "smoke_level",
+        icon="mdi:smoke",
+        name="Smoke Level",
         device_class=SensorDeviceClass.AQI,
     ),
     SensorEntityDescription(
-        "life", icon="mdi:calendar-clock", name="Weeks to replace",
-        state_class=SensorStateClass.MEASUREMENT, native_unit_of_measurement=UnitOfTime.WEEKS,
+        "co_level",
+        icon="mdi:molecule-co",
+        name="CO Level",
+        device_class=SensorDeviceClass.CO,
+    ),
+    SensorEntityDescription(
+        "battery_state",
+        icon="mdi:battery-alert",
+        name="Battery State",
+        device_class=SensorDeviceClass.ENUM,
+        options=["ok", "failed"],
+    ),
+    SensorEntityDescription(
+        "last_seen",
+        icon="mdi:home-clock",
+        name="Last Seen",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        "last_test_time",
+        icon="mdi:home-clock",
+        name="Last Test Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    SensorEntityDescription(
+        "overall_iaq_status",
+        icon="mdi:air-filter",
+        name="Overall Air Quality",
+        device_class=SensorDeviceClass.AQI,
+    ),
+    SensorEntityDescription(
+        "life",
+        icon="mdi:calendar-clock",
+        name="Weeks to replace",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.WEEKS,
     ),
 )
 
 _MEASUREMENTSENSOR_DESCRIPTIONS = (
     SensorEntityDescription(
-        "iaq_temperature", name="Indoor Temperature",
-        device_class=SensorDeviceClass.TEMPERATURE
+        "iaq_temperature",
+        name="Indoor Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
     ),
     SensorEntityDescription(
-        "humidity", name="Humidity",
-        device_class=SensorDeviceClass.HUMIDITY
+        "humidity",
+        name="Humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
     ),
     SensorEntityDescription(
-        "hpa", name="Air Pressure",
-        device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE
+        "hpa",
+        name="Air Pressure",
+        device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE,
     ),
     SensorEntityDescription(
-        "tvoc", name="Total VOC",
-        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS
+        "tvoc",
+        name="Total VOC",
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
     ),
     SensorEntityDescription(
-        "iaq", name="Indoor Air Quality",
-        device_class=SensorDeviceClass.AQI
+        "iaq",
+        name="Indoor Air Quality",
+        device_class=SensorDeviceClass.AQI,
     ),
     SensorEntityDescription(
-        "co2", name="CO₂ Level",
-        device_class=SensorDeviceClass.CO2
+        "co2",
+        name="CO₂ Level",
+        device_class=SensorDeviceClass.CO2,
     ),
 )
 
@@ -93,11 +121,15 @@ async def async_setup_entry(
             sensors.append(
                 KiddeSensorEntity(coordinator, device_id, entity_description)
             )
-        if "temperature" in coordinator.data.devices[device_id].get("capabilities") and coordinator.data.devices[device_id].get("iaq"):
+        if "temperature" in coordinator.data.devices[device_id].get(
+            "capabilities"
+        ) and coordinator.data.devices[device_id].get("iaq"):
             # The unit also has an Indoor Air Quality Monitor
             for measuremententity_description in _MEASUREMENTSENSOR_DESCRIPTIONS:
                 sensors.append(
-                    KiddeSensorMeasurementEntity(coordinator, device_id, measuremententity_description)
+                    KiddeSensorMeasurementEntity(
+                        coordinator, device_id, measuremententity_description
+                    )
                 )
     async_add_devices(sensors)
 
@@ -112,6 +144,7 @@ class KiddeSensorEntity(KiddeEntity, SensorEntity):
         dtype = type(value)
         logger.debug(f"{self.entity_description.key} of type {dtype} is {value}")
         return value
+
 
 class KiddeSensorMeasurementEntity(KiddeEntity, SensorEntity):
     """Measurement Sensor for Kidde HomeSafe."""
@@ -129,15 +162,24 @@ class KiddeSensorMeasurementEntity(KiddeEntity, SensorEntity):
     def native_unit_of_measurement(self) -> string:
         """Return the native unit of measurement of the sensor."""
         match self.kidde_device.get(self.entity_description.key).get("Unit").upper():
-            case "C": return UnitOfTemperature.CELSIUS
-            case "F": return UnitOfTemperature.FAHRENHEIT
-            case "%RH": return PERCENTAGE
-            case "HPA": return UnitOfPressure.HPA
-            case "PPB": return CONCENTRATION_PARTS_PER_BILLION
-            case "PPM": return CONCENTRATION_PARTS_PER_MILLION
-            case _: return None
+            case "C":
+                return UnitOfTemperature.CELSIUS
+            case "F":
+                return UnitOfTemperature.FAHRENHEIT
+            case "%RH":
+                return PERCENTAGE
+            case "HPA":
+                return UnitOfPressure.HPA
+            case "PPB":
+                return CONCENTRATION_PARTS_PER_BILLION
+            case "PPM":
+                return CONCENTRATION_PARTS_PER_MILLION
+            case _:
+                return None
 
     @property
     def extra_state_attributes(self) -> dict:
         """Return additional attributes for the value sensor (Status)."""
-        return {"Status":self.kidde_device.get(self.entity_description.key).get("status")}
+        return {
+            "Status": self.kidde_device.get(self.entity_description.key).get("status")
+        }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Kidde HomeSafe",
   "filename": "kidde.zip",
-  "hide_default_branch": false,
+  "hide_default_branch": true,
   "homeassistant": "2024.3.1",
   "render_readme": true,
   "zip_release": true

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Kidde HomeSafe",
   "filename": "kidde.zip",
-  "hide_default_branch": true,
+  "hide_default_branch": false,
   "homeassistant": "2024.3.1",
   "render_readme": true,
   "zip_release": true


### PR DESCRIPTION
@tache, are you interested in becoming the lead fork for this project? If so, you should enable issues and actions on this repo?

When running this integration, I noticed that the history of some of the sensors could not be viewed correctly. e.g. the smoke levels showed as a state history instead of as a line. This PR fixes that by adding explicit stateclasses and deviceclasses to the sensors, so that the data can be correctly rendered using standard homeassistant UI elements.

As part of this, I also defined a new sensor for the timestamp sensors which converts the string returned by the kidde API into a python datetime. This allows homeassistant to display relative times like "last seen 5 minutes ago" instead of just showing the timestamp.
 