### PR TITLE
add unique entity_id to resolve #9

### DIFF
--- a/custom_components/kidde/entity.py
+++ b/custom_components/kidde/entity.py
@@ -14,6 +14,8 @@ from .coordinator import KiddeCoordinator
 class KiddeEntity(CoordinatorEntity[KiddeCoordinator]):
     """Entity base class."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: KiddeCoordinator,
@@ -43,6 +45,7 @@ class KiddeEntity(CoordinatorEntity[KiddeCoordinator]):
             hw_version=device.get("hwrev"),
             sw_version=str(device.get("fwrev")),
             model=device.get("model"),
+            serial_number=device.get("serial_number"),
             manufacturer=MANUFACTURER,
         )
 

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -32,13 +32,13 @@ logger = logging.getLogger(__name__)
 
 _TIMESTAMP_DESCRIPTIONS = (
     SensorEntityDescription(
-        "last_seen",
+        key="last_seen",
         icon="mdi:home-clock",
         name="Last Seen",
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     SensorEntityDescription(
-        "last_test_time",
+        key="last_test_time",
         icon="mdi:home-clock",
         name="Last Test Time",
         device_class=SensorDeviceClass.TIMESTAMP,
@@ -47,21 +47,21 @@ _TIMESTAMP_DESCRIPTIONS = (
 
 _SENSOR_DESCRIPTIONS = (
     SensorEntityDescription(
-        "smoke_level",
+        key="smoke_level",
         icon="mdi:smoke",
         name="Smoke Level",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.AQI,
     ),
     SensorEntityDescription(
-        "co_level",
+        key="co_level",
         icon="mdi:molecule-co",
         name="CO Level",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CO,
     ),
     SensorEntityDescription(
-        "battery_state",
+        key="battery_state",
         icon="mdi:battery-alert",
         name="Battery State",
         device_class=SensorDeviceClass.ENUM,
@@ -69,7 +69,7 @@ _SENSOR_DESCRIPTIONS = (
         options=["ok", "failed"],
     ),
     SensorEntityDescription(
-        "life",
+        key="life",
         icon="mdi:calendar-clock",
         name="Weeks to replace",
         state_class=SensorStateClass.MEASUREMENT,
@@ -79,40 +79,47 @@ _SENSOR_DESCRIPTIONS = (
 
 _MEASUREMENTSENSOR_DESCRIPTIONS = (
     SensorEntityDescription(
-        "overall_iaq_status",
+        key="overall_iaq_status",
         icon="mdi:air-filter",
         name="Overall Air Quality",
         device_class=SensorDeviceClass.AQI,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        "iaq_temperature",
+        key="iaq_temperature",
         name="Indoor Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        "humidity",
+        key="humidity",
         name="Humidity",
         device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        "hpa",
+        key="hpa",
         name="Air Pressure",
         device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        "tvoc",
+        key="tvoc",
         name="Total VOC",
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        "iaq",
+        key="iaq",
         name="Indoor Air Quality",
         device_class=SensorDeviceClass.AQI,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        "co2",
+        key="co2",
         name="CO₂ Level",
         device_class=SensorDeviceClass.CO2,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 


### PR DESCRIPTION
I want to first off thank you for putting this integration together. 

In this pull request it will resolve the unique `entity_id` issue #9.  I performed some cleanup in the `sensor.py` class, but the majority of the change that makes this possible is setting the flag `_attr_has_entity_name = True` in the `KiddeEntity` class which you can [read about here](https://developers.home-assistant.io/blog/2022/07/10/entity_naming/), if you are interested in how HA standardizes naming.  