### PR TITLE
Added sensors supporting smoke detections and offline status

### DIFF
--- a/custom_components/kidde/binary_sensor.py
+++ b/custom_components/kidde/binary_sensor.py
@@ -35,24 +35,19 @@ _BINARY_SENSOR_DESCRIPTIONS = (
         device_class=BinarySensorDeviceClass.CO,
     ),
     BinarySensorEntityDescription(
-        "hardwire_smoke",
+        key="hardwire_smoke",
         icon="mdi:smoke-detector-variant-alert",
         name="Hardwire Smoke Alarm",
         device_class=BinarySensorDeviceClass.SMOKE,
     ),
     BinarySensorEntityDescription(
-        "too_much_smoke",
+        key="too_much_smoke",
         icon="mdi:smoke-detector-variant-alert",
         name="Too Much Smoke",
         device_class=BinarySensorDeviceClass.SMOKE,
     ),
     BinarySensorEntityDescription(
-        "offline",
-        icon="mdi:smoke-detector-variant-off",
-        name="Offline",
-    ),
-    BinarySensorEntityDescription(
-        "contact_lost",
+        key="contact_lost",
         icon="mdi:smoke-detector-variant-off",
         name="Contact_Lost",
     ),

--- a/custom_components/kidde/binary_sensor.py
+++ b/custom_components/kidde/binary_sensor.py
@@ -34,6 +34,28 @@ _BINARY_SENSOR_DESCRIPTIONS = (
         name="CO Alarm",
         device_class=BinarySensorDeviceClass.CO,
     ),
+    BinarySensorEntityDescription(
+        "hardwire_smoke",
+        icon="mdi:smoke-detector-variant-alert",
+        name="Hardwire Smoke Alarm",
+        device_class=BinarySensorDeviceClass.SMOKE,
+    ),
+    BinarySensorEntityDescription(
+        "too_much_smoke",
+        icon="mdi:smoke-detector-variant-alert",
+        name="Too Much Smoke",
+        device_class=BinarySensorDeviceClass.SMOKE,
+    ),
+    BinarySensorEntityDescription(
+        "offline",
+        icon="mdi:smoke-detector-variant-off",
+        name="Offline",
+    ),
+    BinarySensorEntityDescription(
+        "contact_lost",
+        icon="mdi:smoke-detector-variant-off",
+        name="Contact_Lost",
+    ),
 )
 
 _INVERSE_BINARY_SENSOR_DESCRIPTIONS = (

--- a/custom_components/kidde/binary_sensor.py
+++ b/custom_components/kidde/binary_sensor.py
@@ -45,6 +45,7 @@ _BINARY_SENSOR_DESCRIPTIONS = (
         icon="mdi:smoke-detector-variant-alert",
         name="Too Much Smoke",
         device_class=BinarySensorDeviceClass.SMOKE,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BinarySensorEntityDescription(
         key="contact_lost",


### PR DESCRIPTION
Added additonal sensors supporing smoke detection alerts and offline status. Each is a binary sensor. 

- "hardwire_smoke" 
- "too_much_smoke" 
- "offline"
- "contact_lost"

Would like some review of the icons chosen. 