### PR TITLE
Resolve PA/HPA conversion issue

### DIFF
--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -371,7 +371,7 @@ class KiddeSensorMeasurementEntity(KiddeEntity, SensorEntity):
             case "%RH":
                 return PERCENTAGE
             case "HPA":
-                return UnitOfPressure.HPA
+                return UnitOfPressure.PA
             case "PPB":
                 return CONCENTRATION_PARTS_PER_BILLION
             case "PPM":


### PR DESCRIPTION
Incorrect value reported over API. Value defined as HPA, but is actually PA.

https://github.com/tache/homeassistant-kidde/issues/22

Previous output: 
![image](https://github.com/user-attachments/assets/204aa594-9037-4a15-8b64-20fe0945da2c)

New output:
![image](https://github.com/user-attachments/assets/6d0987e3-482a-45cf-9f04-98445303a076)
