### PR TITLE
Add pytest/ruff CI job and fix broken pytest-asyncio config

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,3 +35,24 @@ jobs:
           category: "integration"
           # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
           ignore: "brands"
+
+  test:
+    name: "Lint and Test"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6.0.2"
+
+      - name: "Set up Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.13"
+
+      - name: "Install dependencies"
+        run: "pip install -r requirements-test.txt"
+
+      - name: "Run ruff"
+        run: "ruff check custom_components/kidde"
+
+      - name: "Run pytest"
+        run: "pytest"

--- a/custom_components/kidde/tests/conftest.py
+++ b/custom_components/kidde/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Fixtures for Kidde HomeSafe tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading this custom integration in every test."""
+    yield

--- a/custom_components/kidde/tests/test_init.py
+++ b/custom_components/kidde/tests/test_init.py
@@ -7,7 +7,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.kidde import async_setup_entry, async_unload_entry
 from custom_components.kidde.const import DOMAIN
 
 
@@ -27,7 +26,8 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
         "custom_components.kidde.coordinator.KiddeCoordinator.async_refresh",
         return_value=AsyncMock(),
     ) as mock_refresh:
-        assert await async_setup_entry(hass, entry) is True
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
         assert entry.state == ConfigEntryState.LOADED
         assert mock_refresh.call_count == 1
 
@@ -45,6 +45,8 @@ async def test_async_unload_entry(hass: HomeAssistant) -> None:
 
     # Mock setup and unload functions
     with patch("custom_components.kidde.PLATFORMS", ["sensor", "switch"]):
-        await async_setup_entry(hass, entry)
-        assert await async_unload_entry(hass, entry) is True
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
         assert entry.state == ConfigEntryState.NOT_LOADED

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = .
+testpaths = custom_components/kidde/tests
+asyncio_mode = auto

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+pytest-asyncio
+pytest-homeassistant-custom-component

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 colorlog==6.10.1
 homeassistant
+kidde-homesafe==0.0.3
 pip
 ruff==0.14.14


### PR DESCRIPTION
Adds a CI job that runs `ruff` and `pytest` on every push/PR — until now only Hassfest and HACS validation ran automatically, so lint and test regressions went unnoticed. Also fixes the underlying gaps that were silently breaking most of the existing test suite: no `asyncio_mode = auto` config, no `enable_custom_integrations` fixture, and two tests in `test_init.py` that called `async_setup_entry`/`async_unload_entry` directly instead of going through `hass.config_entries`. All 16 existing tests pass now; previously only 10 did.