### PR TITLE
Silence noisy iaq unit warning while keeping it for other sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed the `battery_state` sensor entity to "Battery State Detail" so it no
   longer shares the "Battery State" name with the existing binary sensor on
   the same device page (fixes #129)
+- Stopped logging a warning on every poll for the `iaq` sensor specifically,
+  which carries no unit value in the API response (the `Unit` key is absent
+  or an empty string) since it's a unitless score by design, not an
+  unrecognized value. Scoped to `iaq` only (not any empty unit) so a
+  genuinely missing unit on any other measurement sensor still warns as
+  before (fixes #131)
 
 ### Testing
-- Added 4 unit tests covering the `battery_state` mapping and the setup-time-
-  mutation regression from #128
+- Added 7 unit tests covering the `battery_state` mapping, the setup-time-
+  mutation regression from #128, and the unitless-sensor log noise from #131
 
 ## [0.2.0] - 2026-09-03
 

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -558,6 +558,13 @@ class KiddeSensorMeasurementEntity(KiddeEntity, SensorEntity):
 
         entity_unit = entity_dict.get(KEY_UNIT, "").upper()
 
+        if not entity_unit and self.entity_description.key == KEY_IAQ:
+            # iaq (Indoor Air Quality index) is a unitless score by design,
+            # so its Unit is expected to be absent or an empty string; that's
+            # not an unrecognized value, so it doesn't warrant a warning like
+            # other measurement sensors would for a missing/unknown unit.
+            return None
+
         match entity_unit:
             case "C":
                 return UnitOfTemperature.CELSIUS

--- a/custom_components/kidde/tests/test_sensor.py
+++ b/custom_components/kidde/tests/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Kidde HomeSafe sensor platform."""
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -286,6 +287,92 @@ class TestKiddeSensorMeasurementEntity:
         entity = KiddeSensorMeasurementEntity(mock_coordinator, "device1", description)
 
         assert entity.native_unit_of_measurement == CONCENTRATION_PARTS_PER_BILLION
+
+    @pytest.mark.asyncio
+    async def test_measurement_entity_unitless_no_warning(
+        self, mock_coordinator, caplog
+    ):
+        """Test a unitless sensor like iaq returns None without a log warning.
+
+        The `iaq` field is unitless by design (see issue #131), so its Unit
+        is expected to be absent -- that's not an unrecognized unit. The
+        mock_coordinator fixture omits the Unit key entirely for iaq.
+        """
+        from homeassistant.components.sensor import SensorEntityDescription
+
+        description = SensorEntityDescription(
+            key="iaq",
+            name="Indoor Air Quality",
+        )
+
+        entity = KiddeSensorMeasurementEntity(mock_coordinator, "device1", description)
+
+        with caplog.at_level(logging.DEBUG, logger="custom_components.kidde.sensor"):
+            result = entity.native_unit_of_measurement
+
+        assert result is None
+        assert "Unknown unit" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_measurement_entity_unitless_empty_string_no_warning(
+        self, mock_coordinator, caplog
+    ):
+        """Test iaq with an explicit empty-string Unit is also silent.
+
+        Real API captures show both shapes for iaq: some omit the Unit key
+        entirely, others include it as "Unit": "". Both must be silent.
+        """
+        from homeassistant.components.sensor import SensorEntityDescription
+
+        mock_coordinator.data.devices["device1"]["iaq"] = {
+            "value": 124.64,
+            "status": "Moderate",
+            "Unit": "",
+        }
+
+        description = SensorEntityDescription(
+            key="iaq",
+            name="Indoor Air Quality",
+        )
+
+        entity = KiddeSensorMeasurementEntity(mock_coordinator, "device1", description)
+
+        with caplog.at_level(logging.DEBUG, logger="custom_components.kidde.sensor"):
+            result = entity.native_unit_of_measurement
+
+        assert result is None
+        assert "Unknown unit" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_measurement_entity_empty_unit_still_warns_for_other_keys(
+        self, mock_coordinator, caplog
+    ):
+        """Test an empty unit on a non-iaq field still logs a warning.
+
+        Only `iaq` is unitless by design (see issue #131) -- every other
+        measurement field observed in real API data always has a unit, so
+        an empty unit there is genuinely unexpected and should still warn.
+        """
+        from homeassistant.components.sensor import SensorEntityDescription
+
+        mock_coordinator.data.devices["device1"]["tvoc"] = {
+            "value": 618.87,
+            "status": "Moderate",
+            "Unit": "",
+        }
+
+        description = SensorEntityDescription(
+            key="tvoc",
+            name="Total VOC",
+        )
+
+        entity = KiddeSensorMeasurementEntity(mock_coordinator, "device1", description)
+
+        with caplog.at_level(logging.DEBUG, logger="custom_components.kidde.sensor"):
+            result = entity.native_unit_of_measurement
+
+        assert result is None
+        assert "Unknown unit" in caplog.text
 
     @pytest.mark.asyncio
     async def test_measurement_entity_extra_attributes(self, mock_coordinator):


### PR DESCRIPTION
## Summary
Fixes #131. `iaq` (Indoor Air Quality index) is a unitless score by design, so its `Unit` field in the Kidde API response is always absent or an empty string — this was being logged as an "Unknown unit" warning on every coordinator poll for every IAQ-capable device.

Added a guard in `KiddeSensorMeasurementEntity.native_unit_of_measurement` that silently returns `None` specifically for `iaq` with no unit, rather than a blanket "any empty unit is fine" rule. Verified against `dev-data-blobs/*.json`: `iaq` is the only one of the 6 measurement fields (`iaq_temperature`, `humidity`, `hpa`, `tvoc`, `iaq`, `co2`) that's ever missing a unit — the other 5 always have one. So the warning stays fully intact for any of them if they ever come through without a unit (a genuine anomaly worth knowing about), and only `iaq`'s known, by-design unitless-ness is silenced.

Went through two rounds of independent review before landing here, including a data survey confirming both real-world shapes for `iaq`'s missing unit (key absent vs. `"Unit": ""`) are covered.

## Test plan
- [x] `pytest custom_components/kidde/tests/` — 29 passed
- [x] `./scripts/lint` — clean
- [x] New test confirms `iaq` with no `Unit` key and with `"Unit": ""` both stay silent
- [x] New "control" test confirms a *different* field (`tvoc`) with `"Unit": ""` still logs the warning, proving the fix doesn't broaden into a blanket empty-unit suppression