### PR TITLE
ci: attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: "ubuntu-latest"
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: "Checkout the repository"
         uses: "actions/checkout@v6.0.2"
@@ -28,6 +30,11 @@ jobs:
         run: |
           cd "${{ github.workspace }}/custom_components/kidde"
           zip kidde.zip -r ./
+
+      - name: "Attest build provenance"
+        uses: "actions/attest-build-provenance@v4.2.2"
+        with:
+          subject-path: "${{ github.workspace }}/custom_components/kidde/kidde.zip"
 
       - name: "Upload the ZIP file to the release"
         uses: softprops/action-gh-release@v2.5.0


### PR DESCRIPTION
Generates a signed build-provenance attestation for `kidde.zip` on every published release, so users can cryptographically verify a download came from this repo's release workflow.

## Changes

- Adds `id-token: write` and `attestations: write` to the release job's permissions (required for Sigstore signing)
- Adds an `actions/attest-build-provenance@v4.2.2` step, placed after the zip is built and before it is uploaded, so the attested bytes are exactly the bytes users download

## Verifying

After the next published release:

```bash
gh attestation verify kidde.zip --repo tache/homeassistant-kidde
```

## Notes

- Takes effect on the **next** published release; existing assets (including `v0.2.1`) remain unattested
- CI-only change, no effect on the integration's runtime behavior