### PR TITLE
ci: also build and attest when a pre-release is promoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - "published"
+      - "released"
 
 permissions: {}
 


### PR DESCRIPTION
Adds `released` to the release workflow's trigger types.

## Why

GitHub fires `published` when a release or pre-release is first published, but fires `released` when an existing pre-release is converted to a full release. The workflow only listened for `published`, so promoting a pre-release to Latest ran no CI at all — the attached artifact stayed exactly as originally built, with no rebuild and no attestation.

This was observed on `v0.2.1`: promoting it to Latest produced no workflow run, leaving an unattested `kidde.zip` as the current Latest download.

## Effect

Promoting a pre-release now rebuilds the zip, generates its build-provenance attestation, and re-uploads it to the release.

Note that publishing as a pre-release and later promoting will now trigger two runs — `published` on the first, `released` on the second. This is harmless: the asset is overwritten and a fresh attestation is created for the new bytes.