### PR TITLE
ci: also build and attest when a pre-release is promoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - "published"
+      - "released"
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - Unreleased
+## [0.2.2] - Unreleased
+
+### Added
+- Build provenance attestation for release artifacts. The `kidde.zip` attached
+  to a release now carries a signed attestation of how and where it was built,
+  verifiable with
+  `gh attestation verify kidde.zip --repo tache/homeassistant-kidde` (#136)
+
+### Fixed
+- Release workflow now also runs when a pre-release is promoted to a full
+  release. Previously only the initial publish triggered a build, so promoting
+  a pre-release left the original artifact in place with no rebuild and no
+  attestation (#139)
+
+## [0.2.1] - 2026-09-04
 
 ### Changed
 - `KiddeSensorMappedEntity` generalized to accept string-keyed mappings in


### PR DESCRIPTION
Adds `released` to the release workflow's trigger types, plus the accompanying changelog updates.

## Why

GitHub fires `published` when a release or pre-release is first published, but fires `released` when an existing pre-release is converted to a full release. The workflow only listened for `published`, so promoting a pre-release to Latest ran no CI at all — the attached artifact stayed exactly as originally built, with no rebuild and no attestation.

This was observed on `v0.2.1`: promoting it to Latest produced no workflow run, leaving an unattested `kidde.zip` as the current Latest download.

## Effect

Promoting a pre-release now rebuilds the zip, generates its build-provenance attestation, and re-uploads it to the release.

Note that publishing as a pre-release and later promoting will now trigger two runs — `published` on the first, `released` on the second. This is harmless: the asset is overwritten and a fresh attestation is created for the new bytes.

## Changelog

- `0.2.1` was still marked `Unreleased` despite shipping; dated `2026-09-04`, matching the local-time convention used by the `0.2.0` entry
- Added a `0.2.2 - Unreleased` section covering the build provenance attestation (#136) and this trigger fix

Replaces #138.
