### PR TITLE
feat: add options flow for update interval (fixes #135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.2] - Unreleased
 
 ### Added
+- Options flow for the update interval. The polling interval can now be changed
+  after setup from Settings -> Devices & Services -> Kidde HomeSafe ->
+  Configure, instead of only at initial setup. The entry reloads automatically
+  so the new interval applies immediately, with no loss of entities or history
+  (fixes #135)
 - Build provenance attestation for release artifacts. The `kidde.zip` attached
   to a release now carries a signed attestation of how and where it was built,
   verifiable with
   `gh attestation verify kidde.zip --repo tache/homeassistant-kidde` (#136)
 
 ### Fixed
+- README documented a "Configure" option for the update interval that did not
+  exist, and pointed at "Reconfigure" for credential problems. The Configure
+  flow now exists, and the troubleshooting steps describe the actual
+  re-authentication prompt (fixes #135)
 - Release workflow now also runs when a pre-release is promoted to a full
   release. Previously only the initial publish triggered a build, so promoting
   a pre-release left the original artifact in place with no rebuild and no
   attestation (#139)
+
+### Testing
+- Added 5 tests covering the options flow (update, minimum-interval rejection,
+  pre-filled default) and the options-over-data precedence at setup
 
 ## [0.2.1] - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ During setup, you can configure how often the integration polls the Kidde API fo
 - Generate more API calls to Kidde's servers
 - Potentially trigger rate limiting (though not currently observed)
 
-You can adjust this setting by:
+You can change the interval at any time after setup:
 1. Go to Settings → Devices & Services
 2. Find "Kidde HomeSafe" and click "Configure"
-3. Adjust the "Update Interval (seconds)" field
+3. Adjust the "Update Interval (seconds)" field and submit
+
+The integration reloads automatically, so the new interval takes effect
+immediately. Your devices, entities, and history are preserved.
 
 ## Troubleshooting
 
@@ -56,15 +59,16 @@ You can adjust this setting by:
 
 If you see errors like `Cannot connect to host api.homesafe.kidde.com` or authentication failures:
 
-1. **Go to Settings → Devices & Services**
-2. **Find "Kidde HomeSafe" in your integrations list**
-3. **Click the three dots (⋮) on the Kidde integration**
-4. **Select "Reconfigure"** (or "Configure" if available)
-5. **Re-enter your credentials** to refresh authentication
+When authentication fails, Home Assistant surfaces a "Reconfigure" prompt on
+the integration itself — open Settings → Devices & Services and follow it to
+re-enter your credentials.
+
+Note that "Configure" is not the same thing: it only adjusts the update
+interval and does not touch your credentials.
 
 **Alternative - Delete and Re-add:**
 
-If "Reconfigure" isn't available:
+If no re-authentication prompt appears:
 1. Settings → Devices & Services
 2. Find "Kidde HomeSafe" and click the three dots (⋮)
 3. Select "Delete"

--- a/custom_components/kidde/__init__.py
+++ b/custom_components/kidde/__init__.py
@@ -28,14 +28,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     client = KiddeClient(entry.data["cookies"])
+    # The interval chosen at setup is stored in data; later edits from the
+    # options flow are stored in options, which therefore wins.
+    update_interval = entry.options.get(
+        "update_interval", entry.data["update_interval"]
+    )
     hass.data[DOMAIN][entry.entry_id] = coordinator = KiddeCoordinator(
-        hass, client, update_interval=entry.data["update_interval"]
+        hass, client, update_interval=update_interval
     )
     await coordinator.async_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry so a changed update interval takes effect."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/kidde/config_flow.py
+++ b/custom_components/kidde/config_flow.py
@@ -6,7 +6,8 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from kidde_homesafe import KiddeClient, KiddeClientAuthError
 
@@ -34,6 +35,12 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Kidde HomeSafe."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> KiddeOptionsFlow:
+        """Return the options flow for adjusting the update interval."""
+        return KiddeOptionsFlow()
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -113,4 +120,42 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "account": self._reauth_entry.title if self._reauth_entry else "Unknown"
             },
+        )
+
+
+class KiddeOptionsFlow(OptionsFlow):
+    """Handle options for Kidde HomeSafe.
+
+    Exposes the update interval for editing after setup. The value chosen at
+    setup lives in the entry's data, so the current interval is read from the
+    entry's options first and falls back to that original data value.
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the update interval."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            update_interval = user_input["update_interval_seconds"]
+            if isinstance(update_interval, int) and update_interval >= 5:
+                return self.async_create_entry(
+                    data={"update_interval": update_interval}
+                )
+            errors["base"] = "invalid_update_interval"
+
+        current_interval = self.config_entry.options.get(
+            "update_interval", self.config_entry.data["update_interval"]
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        "update_interval_seconds", default=current_interval
+                    ): int
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/kidde/strings.json
+++ b/custom_components/kidde/strings.json
@@ -26,5 +26,18 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Kidde HomeSafe options",
+        "data": {
+          "update_interval_seconds": "[%key:common::config_flow::data::update_interval_seconds%]"
+        }
+      }
+    },
+    "error": {
+      "invalid_update_interval": "[%key:common::config_flow::error::invalid_update_interval%]"
+    }
   }
 }

--- a/custom_components/kidde/tests/test_config_flow.py
+++ b/custom_components/kidde/tests/test_config_flow.py
@@ -151,3 +151,73 @@ async def test_reauth_flow_invalid_auth(hass: HomeAssistant) -> None:
 
         # Verify the entry was NOT updated
         assert entry.data["cookies"] == "old_cookies"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_updates_interval(hass: HomeAssistant) -> None:
+    """Test the options flow writes a new update interval to the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"cookies": "test_cookies", "update_interval": 30},
+        unique_id="test_entry_id",
+        title="Kidde (test@example.com)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"update_interval_seconds": 90}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options["update_interval"] == 90
+
+    # The original setup value stays in data; options takes precedence.
+    assert entry.data["update_interval"] == 30
+
+
+@pytest.mark.asyncio
+async def test_options_flow_rejects_interval_below_minimum(
+    hass: HomeAssistant,
+) -> None:
+    """Test the options flow refuses an interval under 5 seconds."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"cookies": "test_cookies", "update_interval": 30},
+        unique_id="test_entry_id",
+        title="Kidde (test@example.com)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"update_interval_seconds": 4}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["base"] == "invalid_update_interval"
+    assert not entry.options
+
+
+@pytest.mark.asyncio
+async def test_options_flow_defaults_to_current_interval(
+    hass: HomeAssistant,
+) -> None:
+    """Test the form is pre-filled from options, falling back to data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"cookies": "test_cookies", "update_interval": 30},
+        options={"update_interval": 120},
+        unique_id="test_entry_id",
+        title="Kidde (test@example.com)",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    schema_defaults = {
+        key.schema: key.default() for key in result["data_schema"].schema
+    }
+    assert schema_defaults["update_interval_seconds"] == 120

--- a/custom_components/kidde/tests/test_init.py
+++ b/custom_components/kidde/tests/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Kidde HomeSafe integration."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -34,6 +35,53 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert entry.state == ConfigEntryState.LOADED
         assert mock_refresh.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_prefers_update_interval_from_options(
+    hass: HomeAssistant,
+) -> None:
+    """The options value overrides the interval chosen at setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"cookies": "mock_cookie", "update_interval": 60},
+        options={"update_interval": 15},
+        unique_id="test_entry_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.kidde.coordinator.KiddeCoordinator.async_refresh",
+        return_value=AsyncMock(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator.update_interval == timedelta(seconds=15)
+
+
+@pytest.mark.asyncio
+async def test_setup_falls_back_to_update_interval_from_data(
+    hass: HomeAssistant,
+) -> None:
+    """The setup value is used while no option has been set."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"cookies": "mock_cookie", "update_interval": 60},
+        unique_id="test_entry_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.kidde.coordinator.KiddeCoordinator.async_refresh",
+        return_value=AsyncMock(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator.update_interval == timedelta(seconds=60)
 
 
 @pytest.mark.asyncio

--- a/custom_components/kidde/translations/en.json
+++ b/custom_components/kidde/translations/en.json
@@ -26,5 +26,18 @@
       "already_configured": "Already configured.",
       "reauth_successful": "Re-authentication was successful."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Kidde HomeSafe options",
+        "data": {
+          "update_interval_seconds": "Update Interval (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_update_interval": "Invalid update interval, must be >= 5 seconds."
+    }
   }
 }


### PR DESCRIPTION
Adds an options flow so the polling interval can be changed after setup, and corrects the README text that documented a "Configure" step which did not exist.

Fixes #135.

## Changes

- **`config_flow.py`** — `async_get_options_flow` plus `KiddeOptionsFlow`, reusing the same `>= 5` validation as initial setup. Its presence is what makes Home Assistant render the "Configure" button.
- **`__init__.py`** — the interval is now read from `entry.options` with `entry.data` as the fallback, and an update listener reloads the entry when options change. Registered via `entry.async_on_unload` so repeated reloads do not stack listeners.
- **`strings.json` / `translations/en.json`** — `options` block for the new step and its error.
- **`README.md`** — the Configure steps are now accurate. Also fixed the troubleshooting section, which told users to click "Configure" to re-enter credentials; that would now open an interval-only form. It describes the actual re-authentication prompt instead.

## Data vs options

The interval chosen at setup stays in `entry.data`; edits are written to `entry.options`. Existing installs therefore need no migration — they have no options, so the fallback returns their original value — and the reauth flow, which copies `data["update_interval"]` forward, is unaffected.

## Verification

Unit tests cover the options flow (successful update, rejection below the 5-second minimum, form pre-filled from options with data as fallback) and the options-over-data precedence at setup. Full suite: 34 passed, ruff clean.

Verified live against a real Home Assistant instance as well, since "the update listener actually fires" is not visible in the diff. Interval changed 30 -> 300 -> 30 through the Configure UI with no restart, and `tcpdump` on the Kidde API endpoints confirmed the polling cadence followed each change, to the second.
