### PR TITLE
chore: date the 0.2.2 changelog entry for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] - Unreleased
+## [0.2.2] - 2026-09-07
 
 ### Added
 - Options flow for the update interval. The polling interval can now be changed


### PR DESCRIPTION
Marks the `0.2.2` changelog section as released, dated 2026-09-07, matching the local-date convention used by the entries below it.

Release prep only — no code changes. Merging this leaves `main` ready to tag as `v0.2.2`.

The section already carries its content from #136, #139, and #140: the options flow for the update interval, the README corrections, build provenance attestation, and the release-on-promotion trigger fix.