### PR TITLE
chore: pin the runtime dependency and guard it against requirements.txt

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,0 @@
-pip==23.3.1
-pre-commit==3.5.0
-black==23.11.0
-flake8==6.1.0
-reorder-python-imports==3.12.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,21 @@ jobs:
         with:
           python-version: "3.13"
 
+      # Home Assistant installs from manifest.json, while the tests run against
+      # requirements.txt. If those pins drift, users get a version that was
+      # never tested. Dependabot only updates requirements.txt, so this fails
+      # its PR until the manifest pin is updated to match.
+      - name: "Check manifest and requirements pins agree"
+        shell: "bash"
+        run: |
+          pin=$(python3 -c "import json; print(json.load(open('custom_components/kidde/manifest.json'))['requirements'][0])")
+          if ! grep -qxF "$pin" requirements.txt; then
+            echo "manifest.json requires '$pin', which requirements.txt does not pin identically."
+            echo "Update both so the tested version is the version users install."
+            exit 1
+          fi
+          echo "manifest.json and requirements.txt agree on '$pin'"
+
       - name: "Install dependencies"
         run: "pip install -r requirements-test.txt"
 

--- a/custom_components/kidde/manifest.json
+++ b/custom_components/kidde/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tache/homeassistant-kidde/issues",
   "requirements": [
-    "kidde-homesafe"
+    "kidde-homesafe==0.0.3"
   ],
   "version": "0.2.0"
 }


### PR DESCRIPTION
Home Assistant installs the runtime dependency from `manifest.json`, while CI tests against `requirements.txt`. Those two were allowed to drift: the manifest requested `kidde-homesafe` unpinned, so users got whatever was newest on PyPI, while CI only ever exercised the pinned version.

## Changes

- **Pin the manifest** to `kidde-homesafe==0.0.3`, matching `requirements.txt`. Verified against PyPI: 0.0.3 is the current release and has been since 2023-11-10.
- **Add a CI guard** so the two can never silently diverge again. Dependabot only updates `requirements.txt`, so its PR now fails until the manifest pin is updated to match.
- **Delete `.github/workflows/constraints.txt`**, which was dead — nothing referenced it, and it pinned tooling (`pip`, `pre-commit`, `black`, `flake8`, `reorder-python-imports`) this repo no longer uses.

## Note on ordering

This touches `.github/workflows/validate.yml`, as do the open Dependabot PRs bumping `actions/checkout` and `actions/setup-python`. They edit different lines, so there is no textual conflict — merging this first simply lets Dependabot rebase the rest cleanly.
