### PR TITLE
chore: move ruff config under [lint] and fix RUF036

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,6 +3,7 @@
 target-version = "py312"
 line-length = 89
 
+[lint]
 select = [
     "A",       # prevent using keywords that clobber python builtins
     "B",       # bugbear: security warnings
@@ -51,11 +52,11 @@ fixable = [
     "RUF100", # Remove unused noqa comments.
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[pyupgrade]
+[lint.pyupgrade]
 keep-runtime-typing = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25

--- a/custom_components/kidde/sensor.py
+++ b/custom_components/kidde/sensor.py
@@ -496,7 +496,7 @@ class KiddeSensorEntity(KiddeEntity, SensorEntity):
     """Sensor for Kidde HomeSafe."""
 
     @property
-    def native_value(self) -> str | None | float | int:
+    def native_value(self) -> str | float | int | None:
         """Return the native value of the sensor."""
         value = self.kidde_device.get(self.entity_description.key)
         dtype = type(value)


### PR DESCRIPTION
Unblocks Dependabot #142 (ruff 0.14.14 to 0.16.6), which currently fails CI for two separate reasons.

## 1. Deprecated config layout

Newer ruff no longer accepts the linter settings at the top level of `.ruff.toml`:

```
warning: The top-level linter settings are deprecated in favour of their
         counterparts in the `lint` section. Please update .ruff.toml:
         'fixable' -> 'lint.fixable'
         'ignore'  -> 'lint.ignore'
         'select'  -> 'lint.select'
         'flake8-pytest-style' -> 'lint.flake8-pytest-style'
         'mccabe'  -> 'lint.mccabe'
         'pyupgrade' -> 'lint.pyupgrade'
```

`select`, `ignore` and `fixable` now sit under `[lint]`, and the three sub-tables are renamed. `target-version` and `line-length` stay at the top level, since they are not linter settings. No rule selection changed.

## 2. RUF036

```
RUF036 `None` not at the end of the type union
  --> custom_components/kidde/sensor.py:499
      def native_value(self) -> str | None | float | int:
```

Reordered to `str | float | int | None`. This is the only occurrence in the codebase. Purely a type-annotation ordering change with no runtime effect.

## Verification

Both changes are valid under the currently pinned ruff (0.14.14) as well as 0.16.6, so this can merge before the Dependabot bump rather than alongside it. Locally: `ruff check custom_components/kidde` passes with no deprecation warning, and all 34 tests pass.
