### PR TITLE
ci: drop the brands ignore now that brand images exist

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,8 +33,6 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-          ignore: "brands"
 
   test:
     name: "Lint and Test"


### PR DESCRIPTION
The HACS validation job has been skipping the brand check since the repo was set up, via an `ignore: "brands"` key. The comment directly above it said to remove that key once brand images existed.

They exist, and have since November 2023: `home-assistant/brands` contains `custom_integrations/kidde/icon.png` and `logo.png` (added in home-assistant/brands#4907).

Brand entries are keyed on the integration `domain`, not on a repository. This integration's manifest declares `"domain": "kidde"`, so HACS resolves it to that directory. Nothing needed to be uploaded.

The comment is removed along with the key, since it existed only to describe removing it.

This PR is the test: if the HACS Validation job passes, the ignore was stale and the check now runs for real. If it fails, that tells us something the ignore was hiding, and the two lines go back.
